### PR TITLE
dependencies fixed

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -25,7 +25,8 @@
         {
             "name": "unittest",
             "dependencies": {
-                "fluent-asserts": "~>0.11.4",
+                "fluent-asserts": "~>0.11",
+                "trial": "~>0.7",
                 "vibe-d:tls": "*"
             },
             "subConfigurations": {

--- a/examples/vibe/dub.json
+++ b/examples/vibe/dub.json
@@ -4,8 +4,12 @@
         "Andrew Benton"
     ],
     "dependencies": {
-        "prometheus": "~>0.1.0",
-        "prometheus:vibe": "~>0.1.0",
+        "prometheus": {
+            "path": "../../"
+        },
+        "prometheus:vibe": {
+            "path": "../../"
+        },
         "vibe-d": "~>0.8.3",
         "vibe-d:tls": "*"
     },


### PR DESCRIPTION
Fixed
* Non-optional dependency trial:lifecylce of prometheus not found in dependency tree!?.
* Made the vibe.d example depend on the git not on code.dlang.org

@andrewbenton could you create a new release from this. We have to have a local version of prometheus currently to get around this.